### PR TITLE
Add version switcher to docs

### DIFF
--- a/docs/source/_static/switcher.json
+++ b/docs/source/_static/switcher.json
@@ -1,0 +1,13 @@
+[
+    {
+        "name": "dev",
+        "version": "0.0.2.dev0",
+        "url": "https://ampworks.readthedocs.io/en/latest/"
+    },
+    {
+        "name": "stable",
+        "version": "0.0.1",
+        "url": "https://ampworks.readthedocs.io/en/stable/",
+        "preferred": true
+    }
+]

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -14,6 +14,8 @@ author = 'Corey R. Randall'
 version = amp.__version__
 release = amp.__version__
 
+json_url = 'https://ampworks.readthedocs.io/en/latest/_static/switcher.json'
+
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
@@ -88,6 +90,11 @@ html_theme_options = {
     'collapse_navigation': True,
     'show_toc_level': 0,
     'pygments_light_style': 'tango',
+    'show_version_warning_banner': True,
+    'switcher': {
+        'json_url': json_url,
+        'version_match': version,
+    }
 }
 
 # -- Options for napoleon ----------------------------------------------------


### PR DESCRIPTION
# Description
Adds the warning banner to the docs so users can be more easily directed to the stable version instead of the development version or an older release.

## Type of change
- [x] New feature (non-breaking change which adds functionality)

# Key checklist:
- [x] No style issues: `$ nox -s linter [-- format]`
- [x] Code is free of misspellings: `$ nox -s codespell [-- write]`
- [x] All tests pass: `$ nox -s tests`
- [x] Badges are updated: `$ nox -s badges`

## Further checks:
- [x] The documentation builds: `$ nox -s docs`.
- [x] Code is commented, particularly in hard-to-understand areas.
- [x] Tests are added that prove fix is effective or that feature works.
