### PR TITLE
Updated dqdv gui working with new figure, style options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased](https://github.com/NREL/ampworks)
 
 ### New Features
+- Update dQdV GUI figure to gridspec with electrode voltages ([#10](https://github.com/NREL/ampworks/pull/10))
 - New `RichTable` container with column validation ([#9](https://github.com/NREL/ampworks/pull/9))
 - Include standard deviations in dQdV fits ([#8](https://github.com/NREL/ampworks/pull/8))
 - Add `utils` subpackage with a handful of basic utilities ([#7](https://github.com/NREL/ampworks/pull/7))
@@ -11,6 +12,7 @@
 - Complete overhaul to `plotutils` for shorter, modular use ([#2](https://github.com/NREL/ampworks/pull/2))
 
 ### Optimizations
+- Store custom plotly template and config in `_style` module ([#10](https://github.com/NREL/ampworks/pull/10))
 - Added tests for `gitt.extract_params` ([#6](https://github.com/NREL/ampworks/pull/6))
 - Added tests for `ici.extract_params` ([#5](https://github.com/NREL/ampworks/pull/5))
 

--- a/examples/simple_dQdV_example.py
+++ b/examples/simple_dQdV_example.py
@@ -79,7 +79,7 @@ print(summary3, "\n")
 
 # Calculating LAM/LLI
 # ===================
-# If your main purpose for the dQ/dV fitting is to calculate loss of active
+# If your main purpose for the dQdV fitting is to calculate loss of active
 # material (LAM) and loss of lithium inventory (LLI) then you will need to
 # loop over and collect the fitted stoichiometries from many cell datasets
 # throughout life. Use 'DqdvFitResult' class to store all of your results and

--- a/images/coverage.svg
+++ b/images/coverage.svg
@@ -1,5 +1,5 @@
-<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="116" height="20" role="img" aria-label="coverage: 38.39%">
-	<title>coverage: 38.39%</title>
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="116" height="20" role="img" aria-label="coverage: 36.84%">
+	<title>coverage: 36.84%</title>
 	<linearGradient id="s" x2="0" y2="100%">
 		<stop offset="0" stop-color="#bbb" stop-opacity=".1"/>
 		<stop offset="1" stop-opacity=".1"/>
@@ -15,7 +15,7 @@
 	<g fill="#fff" text-anchor="middle" font-family="Verdana,Geneva,DejaVu Sans,sans-serif" text-rendering="geometricPrecision" font-size="110">
 		<text aria-hidden="true" x="315.0" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" textLength="510">coverage</text>
 		<text x="315.0" y="140" transform="scale(.1)" fill="#fff" textLength="510">coverage</text>
-		<text aria-hidden="true" x="875.0" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" textLength="450">38.39%</text>
-		<text x="875.0" y="140" transform="scale(.1)" fill="#fff" textLength="450">38.39%</text>
+		<text aria-hidden="true" x="875.0" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" textLength="450">36.84%</text>
+		<text x="875.0" y="140" transform="scale(.1)" fill="#fff" textLength="450">36.84%</text>
 	</g>
 </svg>

--- a/src/ampworks/__init__.py
+++ b/src/ampworks/__init__.py
@@ -12,6 +12,8 @@ includes search functionality and more detailed examples.
 
 """
 
+from typing import TYPE_CHECKING
+
 from ._core import (
     Dataset,
     read_csv,
@@ -37,6 +39,11 @@ __all__ = [
     '_in_notebook',
 ]
 
+if TYPE_CHECKING:
+    from ampworks import (
+        ici, gitt, dqdv, utils, datasets, mathutils, plotutils,
+    )
+
 
 # Lazily load submodules/subpackages
 _lazy_modules = {
@@ -51,15 +58,18 @@ _lazy_modules = {
 
 
 def __getattr__(name):
+    import importlib
+
     if name in _lazy_modules:
-        module = __import__(_lazy_modules[name], fromlist=[name])
+        module = importlib.import_module(_lazy_modules[name])
         globals()[name] = module  # cache for later
         return module
+
     raise AttributeError(f"module {__name__} has no attribute {name}")
 
 
 def __dir__():
-    return list(globals().keys() | __all__)
+    return list(globals()) + list(_lazy_modules)
 
 
 # Check for interactive and notebook environments

--- a/src/ampworks/_core/_dataset.py
+++ b/src/ampworks/_core/_dataset.py
@@ -75,15 +75,14 @@ class Dataset(pd.DataFrame):
                             save: str = None) -> None:
 
         from ampworks import _in_notebook
+        from ampworks.plotutils._style import PLOTLY_CONFIG, PLOTLY_TEMPLATE
 
         fig = px.line(
             self, x=x, y=y, markers=True,
             hover_data={col: True for col in tips},
         )
 
-        fig.update_layout(dragmode='pan')
-
-        config = {'scrollZoom': True}
+        fig.update_layout(template=PLOTLY_TEMPLATE)
 
         in_nb = _in_notebook()
         auto_open = True if not in_nb else False
@@ -94,7 +93,7 @@ class Dataset(pd.DataFrame):
             if not path.endswith('.html'):
                 path += '.html'
 
-            fig.write_html(path, auto_open=auto_open, config=config)
+            fig.write_html(path, auto_open=auto_open, config=PLOTLY_CONFIG)
 
         if in_nb:
-            fig.show(config=config)
+            fig.show(config=PLOTLY_CONFIG)

--- a/src/ampworks/dqdv/__init__.py
+++ b/src/ampworks/dqdv/__init__.py
@@ -1,7 +1,5 @@
 """
-dQdV
-----
-Functions for analyzing dQ/dV data from battery experiments. Provides curve
+Functions for analyzing dQdV data from battery experiments. Provides curve
 extraction and smoothing, fitting methods, and post-processing of degradation
 modes from fitted stoichiometries.
 
@@ -10,13 +8,14 @@ modes from fitted stoichiometries.
 import warnings
 
 from ._dqdv_fitter import DqdvFitter
-from ._tables import AgingTable, DqdvFitTable
+from ._tables import DqdvFitResult, DqdvFitTable, DegModeTable
 from ._lam_lli import calc_lam_lli, plot_lam_lli
 
 __all__ = [
     'DqdvFitter',
-    'AgingTable',
+    'DqdvFitResult',
     'DqdvFitTable',
+    'DegModeTable',
     'calc_lam_lli',
     'plot_lam_lli',
     'run_gui',
@@ -25,36 +24,32 @@ __all__ = [
 
 def run_gui(jupyter_mode: str = 'external', jupyter_height: int = 650) -> None:
     """
-    Run a graphical interface for the Fitter class.
+    Run a graphical dQdV fitting interface.
 
     Parameters
     ----------
     jupyter_mode : {'external', 'inline'}, optional
-        How to display the application when running inside a jupyter notebook.
-        'external' opens an external web browser (default). 'inline' runs the
-        application inside the notebook.
+        How to display the GUI in jupyter notebooks. Run in a new browser tab
+        with 'external' (default), or in the notebook with 'inline'.
     jupyter_height : int, optional
-        Height of the application (in px) when displayed using 'inline'. The
-        default is 650.
+        Application height (px) when displayed using 'inline'. Defaults to 650.
 
     Returns
     -------
     None.
 
-    Notes
-    -----
+    Warnings
+    --------
     This function is only intended for use inside Jupyter Notebooks. You may
     experience issues if you call it from a normal script, or in an interactive
-    session within some IDEs (e.g., Spyder, PyCharm, IPython, etc.). However,
-    if you're looking for an alternate way to access the GUI without needing to
-    open a Jupyter Notebook, you can use the ``ampworks --app`` command from
-    your terminal.
+    session within some IDEs (e.g., Spyder, PyCharm, IPython, etc.). if you're
+    looking for another way to access the GUI without needing to open Jupyter
+    Notebooks, you can use the ``ampworks --app`` command from your terminal.
 
     """
 
+    from ampworks.dqdv.gui_files import _gui
     from ampworks import _in_interactive, _in_notebook
-
-    from .gui_files import _gui
 
     if not isinstance(jupyter_mode, str):
         raise TypeError("'jupyter_mode' must be type str.")

--- a/src/ampworks/dqdv/_lam_lli.py
+++ b/src/ampworks/dqdv/_lam_lli.py
@@ -6,7 +6,7 @@ import pandas as pd
 import matplotlib.pyplot as plt
 
 if TYPE_CHECKING:  # pragma: no cover
-    from ._tables import AgingTable, DqdvFitTable
+    from ._tables import DegModeTable, DqdvFitTable
 
 
 def calc_lam_lli(fit_result: DqdvFitTable) -> pd.DataFrame:
@@ -55,7 +55,7 @@ def calc_lam_lli(fit_result: DqdvFitTable) -> pd.DataFrame:
 
     """
 
-    from ._tables import AgingTable
+    from ._tables import DegModeTable
 
     df = fit_result.df.copy()
 
@@ -101,12 +101,13 @@ def calc_lam_lli(fit_result: DqdvFitTable) -> pd.DataFrame:
         'LLI': LLI, 'LLI_std': LLI_std,
     })
 
-    return AgingTable(aging)
+    return DegModeTable(aging)
 
 
-def plot_lam_lli(aging_table: AgingTable, fit_table: DqdvFitTable,
+def plot_lam_lli(aging_table: DegModeTable, fit_table: DqdvFitTable,
                  x_col: str | None = None, std: bool = True) -> None:
 
+    from ampworks.utils import _ExitHandler
     from ampworks.plotutils import format_ticks
 
     df = pd.concat([aging_table.df, fit_table.df], axis=1)
@@ -156,3 +157,5 @@ def plot_lam_lli(aging_table: AgingTable, fit_table: DqdvFitTable,
 
     # formatting
     format_ticks(axs, xdiv=2, ydiv=2)
+
+    _ExitHandler(plt.show)

--- a/src/ampworks/dqdv/gui_files/_gui.py
+++ b/src/ampworks/dqdv/gui_files/_gui.py
@@ -39,7 +39,7 @@ dummy_block = html.Div(id='dummy-block', className='dummy-block')
 
 main_page = html.Div(
     id='main-page',
-    className='main-page mx-auto my-3',
+    className='main-page mx-auto my-5',
     children=[dash.page_container, setup_page_components()],
 )
 
@@ -73,6 +73,7 @@ app.layout = html.Div(
         grid_container,
     ],
 )
+
 
 # Transform page on width breakpoint
 app.clientside_callback(
@@ -112,6 +113,7 @@ def run(debug: bool = False, jupyter_mode: str = 'external',
         webbrowser.open_new('http://127.0.0.1:8050/')
 
     app.run(
+        port=None,
         debug=debug,
         jupyter_mode=jupyter_mode,
         jupyter_height=jupyter_height,

--- a/src/ampworks/dqdv/gui_files/assets/styles.css
+++ b/src/ampworks/dqdv/gui_files/assets/styles.css
@@ -42,7 +42,7 @@
 }
 
 .main-page {
-    width: 80%;
+    width: 70%;
     grid-row: 1;
     grid-column: 2;
 }

--- a/src/ampworks/dqdv/gui_files/pages/components.py
+++ b/src/ampworks/dqdv/gui_files/pages/components.py
@@ -18,14 +18,14 @@ sliders = dbc.Stack(
                   id='neg-slider-label', class_name='bold-label mt-3'),
         dcc.RangeSlider(
             id='neg-slider', updatemode='drag',
-            min=0.0, max=1.0, step=0.01, value=[0., 1], marks=marks,
+            min=0.0, max=1.0, step=0.01, value=[0., 1.], marks=marks,
         ),
 
         dbc.Label('Positive Electrode: [0.00, 1.00]',
                   id='pos-slider-label', class_name='bold-label mt-3'),
         dcc.RangeSlider(
             id='pos-slider', updatemode='drag',
-            min=0.0, max=1.0, step=0.01, value=[0, 1], marks=marks,
+            min=0.0, max=1.0, step=0.01, value=[0., 1.], marks=marks,
         ),
     ],
     class_name='mx-auto',

--- a/src/ampworks/dqdv/gui_files/pages/figures.py
+++ b/src/ampworks/dqdv/gui_files/pages/figures.py
@@ -3,6 +3,8 @@ import plotly.graph_objs as go
 from dash import dcc
 from plotly.subplots import make_subplots
 
+from ampworks.plotutils._style import PLOTLY_CONFIG, PLOTLY_TEMPLATE
+
 placeholder_fig = go.Figure()
 
 placeholder_fig.update_layout(
@@ -10,7 +12,7 @@ placeholder_fig.update_layout(
     plot_bgcolor='lightgrey',
     xaxis=dict(visible=False),
     yaxis=dict(visible=False),
-    paper_bgcolor='rgba(0, 0, 0, 0)',
+    paper_bgcolor='lightgrey',
     margin=dict(l=20, r=20, t=20, b=20),
 )
 
@@ -21,39 +23,161 @@ placeholder_fig.add_annotation(
     xref='paper', yref='paper', x=0.5, y=0.5,
 )
 
-figure = make_subplots(1, 3)
-
-figure.update_layout(
-    uirevision='constant',
-    font=dict(color='#212529'),
-    margin=dict(l=20, r=20, t=20, b=60),
-    plot_bgcolor='white', paper_bgcolor='white',
-)
-
-y_labels = ['Voltage [V]', 'dsoc/dV [1/V]', 'dV/dsoc [V]']
-
-for i in range(3):
-    figure.update_xaxes(
-        row=1, col=i+1, showgrid=False,
-        ticks='inside', tickcolor='#212529',
-        mirror='allticks', title_text='SOC [-]',
-        showline=True, linewidth=1, linecolor='#212529',
-    )
-    figure.update_yaxes(
-        row=1, col=i+1, showgrid=False,
-        ticks='inside', tickcolor='#212529',
-        mirror='allticks', title_text=y_labels[i],
-        showline=True, linewidth=1, linecolor='#212529',
-    )
-
 figure_div = dcc.Graph(
     id='figure-div',
     responsive=True,
+    config=PLOTLY_CONFIG,
     figure=placeholder_fig,
-    style={'height': '370px', 'width': '100%'},
-    config={
-        'scrollZoom': True,
-        'displaylogo': False,
-        'modeBarButtonsToRemove': ['lasso2d', 'select2d'],
-    },
+    style={'height': '450px', 'width': '100%'},
+)
+
+# 2 rows, 2 columns layout
+figure = make_subplots(
+    rows=2, cols=2,
+    shared_xaxes='columns',
+    vertical_spacing=0.05,
+    horizontal_spacing=0.125,
+    specs=[[{'rowspan': 2, 'secondary_y': True}, {}],
+           [None, {}]]  # None spanned by left plot
+)
+
+for idx in [1, 2]:
+    figure.update_xaxes(row=idx, col=idx, title_text='q [-]')
+
+ylabels = ['dq/dV [1/V]', 'dV/dq [V]']
+for i, row in enumerate([1, 2]):
+    figure.update_yaxes(row=row, col=2, title_text=ylabels[i])
+
+figure.update_yaxes(row=1, col=1, title_text='Voltage (pos/cell) [V]')
+figure.update_yaxes(
+    row=1, col=1, title_text='Voltage (neg) [V]', secondary_y=True)
+
+figure.update_yaxes(mirror=False, row=1, col=1)
+figure.update_yaxes(secondary_y=True, showgrid=False, row=1, col=1)
+
+# vertical lines for soc=0,1
+figure.add_shape(
+    type='line',
+    x0=0, x1=0,
+    y0=0, y1=1,
+    xref='x1', yref='paper',
+    line=dict(color='rgba(64,64,64,1)', width=2, dash='dash')
+)
+
+figure.add_shape(
+    type='line',
+    x0=1, x1=1,
+    y0=0, y1=1,
+    xref='x1', yref='paper',
+    line=dict(color='rgba(64,64,64,1)', width=2, dash='dash')
+)
+
+# data
+figure.add_trace(go.Scatter(
+    x=[], y=[], mode='markers',
+    name='Data', legendgroup='data',
+    marker=dict(
+        size=7,
+        symbol='circle',
+        color='#c5c5c5',
+    )),
+    row=1, col=1,
+)
+figure.add_trace(go.Scatter(
+    x=[], y=[], mode='markers',
+    name='Data', legendgroup='data', showlegend=False,
+    marker=dict(
+        size=7,
+        symbol='circle',
+        color='#c5c5c5',
+    )),
+    row=1, col=2,
+)
+figure.add_trace(go.Scatter(
+    x=[], y=[], mode='markers',
+    name='Data', legendgroup='data', showlegend=False,
+    marker=dict(
+        size=10,
+        symbol='circle',
+        color='#c5c5c5',
+    )),
+    row=2, col=2,
+)
+
+# model
+figure.add_trace(go.Scatter(
+    x=[], y=[], mode='lines',
+    name='Model', legendgroup='model',
+    line=dict(
+        width=2,
+        color='black',
+    )),
+    row=1, col=1,
+)
+figure.add_trace(go.Scatter(
+    x=[], y=[], mode='lines',
+    name='Model', legendgroup='model', showlegend=False,
+    line=dict(
+        width=2,
+        color='black',
+    )),
+    row=1, col=2,
+)
+figure.add_trace(go.Scatter(
+    x=[], y=[], mode='lines',
+    name='Model', legendgroup='model', showlegend=False,
+    line=dict(
+        width=2,
+        color='black',
+    )),
+    row=2, col=2,
+)
+
+# positive electrode
+figure.add_trace(go.Scatter(
+    x=[], y=[], mode='lines', name='Pos',
+    line=dict(
+        width=2,
+        color='#d62728',
+    )),
+    row=1, col=1,
+)
+
+# negative electrode
+figure.add_trace(go.Scatter(
+    x=[], y=[], mode='lines', name='Neg',
+    line=dict(
+        width=2,
+        color='#1f77b4',
+    )),
+    row=1, col=1, secondary_y=True,
+)
+
+# annotations
+figure.add_annotation(
+    text="MAP=nan%",
+    x=0.5, y=0.95,
+    xref="x domain", yref="y domain",
+    showarrow=False,
+    row=1, col=1,
+)
+figure.add_annotation(
+    text="MAP=nan%",
+    x=0.9, y=0.9,
+    xref="x domain", yref="y domain",
+    showarrow=False,
+    row=1, col=2,
+)
+figure.add_annotation(
+    text="MAP=nan%",
+    x=0.9, y=0.9,
+    xref="x domain", yref="y domain",
+    showarrow=False,
+    row=2, col=2,
+)
+
+figure.update_layout(
+    uirevision='constant',
+    template=PLOTLY_TEMPLATE,
+    margin=dict(l=100, r=20, t=20, b=50),
 )

--- a/src/ampworks/gitt/__init__.py
+++ b/src/ampworks/gitt/__init__.py
@@ -1,6 +1,4 @@
 """
-GITT
-----
 Tools to analyze Galvanostatic Intermittent Titration Technique (GITT) data.
 Includes functions to extract diffusion coefficients and equilibrium potentials
 from experimental measurements.

--- a/src/ampworks/ici/__init__.py
+++ b/src/ampworks/ici/__init__.py
@@ -1,6 +1,4 @@
 """
-ICI
----
 Tools to analyze Incremental Current Interruption (ICI) data. Includes functions
 to extract diffusion coefficients and equilibrium potentials from experimental
 measurements.

--- a/src/ampworks/plotutils/_style.py
+++ b/src/ampworks/plotutils/_style.py
@@ -1,0 +1,41 @@
+import plotly.graph_objects as go
+
+
+PLOTLY_TEMPLATE = go.layout.Template(
+    layout=dict(
+        dragmode='pan',
+        plot_bgcolor='white',
+        paper_bgcolor='white',
+        font=dict(family='Arial', size=12, color='#212529'),
+        xaxis=dict(
+            showline=True, linecolor='#212529', title_standoff=7,
+            mirror='all', ticks='inside', tickcolor='#212529',
+            minor=dict(
+                ticklen=2,
+                ticks='inside',
+            ),
+        ),
+        yaxis=dict(
+            showline=True, linecolor='#212529', title_standoff=7,
+            mirror='all', ticks='inside', tickcolor='#212529',
+            minor=dict(
+                ticklen=2,
+                ticks='inside',
+            ),
+        ),
+        legend=dict(
+            orientation='h',
+            bgcolor='rgba(0,0,0,0)',
+            bordercolor='rgba(0,0,0,0)',
+            entrywidth=0.125, entrywidthmode='fraction',
+            xanchor='center', x=0.5, yanchor='top', y=1.15,
+        )
+    )
+)
+
+PLOTLY_CONFIG = {
+    'scrollZoom': True,
+    'responsive': True,
+    'displaylogo': False,
+    'modeBarButtonsToRemove': ['select2d', 'lasso2d'],
+}

--- a/src/ampworks/utils/__init__.py
+++ b/src/ampworks/utils/__init__.py
@@ -5,6 +5,10 @@ progress bars in the console, and more.
 
 """
 
+import atexit
+
+from typing import Callable
+
 from ._timer import Timer
 from ._rich_table import RichTable
 from ._rich_result import RichResult
@@ -18,3 +22,21 @@ __all__ = [
     'ProgressBar',
     'alphanum_sort',
 ]
+
+
+class _ExitHandler:
+    """
+    Exit handler.
+
+    Use this class to register functions that you want to run just before a
+    file exits. This is primarily used to register plt.show() so plots appear
+    in both interactive and non-interactive environments, even if the user
+    forgets to explicitly call it.
+
+    """
+    _registered = []
+
+    @classmethod
+    def register_atexit(cls, func: Callable) -> None:
+        if func not in cls._registered:
+            atexit.register(func)

--- a/src/ampworks/utils/_rich_table.py
+++ b/src/ampworks/utils/_rich_table.py
@@ -40,7 +40,7 @@ class RichTable:
         --------
         A minimal example using ``RichTable`` directly:
 
-        .. code-block::
+        .. code-block:: python
 
             import pandas as pd
             from ampworks.utils import RichTable
@@ -51,7 +51,7 @@ class RichTable:
 
         Subclassing to enforce required columns:
 
-        .. code-block::
+        .. code-block:: python
 
             import pandas as pd
             from ampworks.utils import RichTable

--- a/src/ampworks/utils/_timer.py
+++ b/src/ampworks/utils/_timer.py
@@ -7,28 +7,16 @@ class Timer:
     """
     Timer utility.
 
-    Measures the elapsed time for a series of steps and prints the result to
-    the console. To use this utility, place your code in a ``with`` block.
-    For example,
-
-    .. code-block:: python
-
-        import time
-
-        def function(sleep_time: float) -> None:
-            time.sleep(sleep_time)
-
-        with Timer():
-            function(2.)
-
     """
 
     __slots__ = ('name', '_units', '_converter', '_start', '_stop',)
 
     def __init__(self, name: str = 'Elapsed time', units: str = 's') -> None:
         """
-        Initialize the timer with a name so you can tell what steps each print
-        statement is associated with when timing multiple code blocks.
+        Measures elapsed time for a series of steps and prints results to the
+        console. Initialize with a name to tell what steps each print statement
+        is associated with when timing multiple blocks. Also has control to
+        print in different units of time.
 
         Parameters
         ----------
@@ -36,6 +24,23 @@ class Timer:
             Code block name used in print. The default is 'Elapsed time'.
         units : str, optional
             Printing units, from {'s', 'min', 'h'}. The default is 's'.
+
+        Examples
+        --------
+        The ``Timer`` works as a context manager and is accessed using ``with``
+        blocks. For example:
+
+        .. code-block:: python
+
+        import time
+        from ampworks.utils import Timer
+
+        def function(sleep_time: float) -> None:
+            time.sleep(sleep_time)
+
+        with Timer():
+            function(2.)
+
 
         """
 


### PR DESCRIPTION
# Description
dQdV GUI figure now matches the style/detail from `DqdvFitter.plot()`. Electrode curves are shown in voltage plot and subfigures are on gridspec instead of in a single row. Also added new `_style` module in `plotutils` with reusable template and config settings for all plotly figures.

## Type of change
- [x] New feature (non-breaking change which adds functionality)
- [x] Optimization (back-end change that improves speed/readability/etc.)
- [ ] Bug fix (non-breaking change which fixes an issue)

# Key checklist:
- [x] No style issues: `$ nox -s linter [-- format]`
- [x] Code is free of misspellings: `$ nox -s codespell [-- write]`
- [x] All tests pass: `$ nox -s tests`
- [x] Badges are updated: `$ nox -s badges`

## Further checks:
- [x] The documentation builds: `$ nox -s docs`.
- [x] Code is commented, particularly in hard-to-understand areas.
- [x] Tests are added that prove fix is effective or that feature works.
